### PR TITLE
Removing warning for ip4GatewayAddress

### DIFF
--- a/eflowautodeploy/eflowAutoDeploy.ps1
+++ b/eflowautodeploy/eflowAutoDeploy.ps1
@@ -209,12 +209,6 @@ function Test-EadUserConfigNetwork {
             $ipconfigstatus = $false
         } else {
             $status = Test-Connection $nwCfg.ip4GatewayAddress -Count 1 -Quiet
-            if (($status) -and ($nwCfg.vSwitchType -ieq "Internal")) {
-                # flagging it as a warning for now. To be fixed.
-                Write-Host "Warning: ip4GatewayAddress $($nwCfg.ip4GatewayAddress) may be in use already" -ForegroundColor Yellow
-                #$errCnt += 1
-                #$ipconfigstatus = $false
-            }
             if ((-not $status) -and ($nwCfg.vSwitchType -ieq "External")) {
                 Write-Host "Error: ip4GatewayAddress $($nwCfg.ip4GatewayAddress) is not reachable. Required for external switch" -ForegroundColor Red
                 $errCnt += 1


### PR DESCRIPTION
When connecting to the network, the ip4GatewayAddress will always be used, as this is the gateway address that will be used as first link from the device to talk to the network.